### PR TITLE
Fix build script typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ schema.json
 
 # misc
 .DS_Store
+.idea
 *.pem
 .eslintcache
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "dev": "npm-run-all --parallel --race next:dev watch-typegen",
-    "built": "npm run next:build",
+    "build": "npm run next:build",
     "start": "npm run next:start",
     "sanity:typegen": "mkdir -p ./.sanity && sanity schema extract --path=.sanity/schema.json && sanity typegen generate",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
### Description of the Change
Fixes a typo in the `build` script (was `built`).
Also, added `.idea` directory to `.gitignore`

Closes #62

### How to test the Change
- Run `npm run build`