### PR TITLE
Remove duplicate cn function

### DIFF
--- a/src/components/sections/MediaText.tsx
+++ b/src/components/sections/MediaText.tsx
@@ -3,7 +3,7 @@ import { Image } from 'next-sanity/image';
 import PortableText from '@/components/modules/PortableText';
 import { urlForImage } from '@/lib/sanity/client/utils';
 import type { MediaTextSectionFragmentType } from '@/lib/sanity/queries/fragments/fragment.types';
-import { cn } from '@/utils/styles';
+import { cn } from '@/lib/utils';
 
 export default function MediaTextSection({ section }: { section: MediaTextSectionFragmentType }) {
   return (

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}


### PR DESCRIPTION
### Description of the Change
Remove duplicate `cn` function.

Closes #63

### How to test the Change
Verify there is no regression in the MediaTextSection component class rendering.